### PR TITLE
ENH: Add `.idea` folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Editor temporary/working/backup files
+.idea/


### PR DESCRIPTION
Add `.idea` folder (JetBrains' project settings folder)  to `.gitignore`.