### PR TITLE
Add help function, restrict gh call to certain labels and change the way tabs are introduced into tsv

### DIFF
--- a/tools/pull_issues.sh
+++ b/tools/pull_issues.sh
@@ -53,16 +53,13 @@ fi
 ISSUE_ID_LIST=$(gh issue list -L 1000 -l "${EVENT}"| awk '{print $1}')
 
 # Create output file and add header.
-echo "ID    TITLE    LABELS \n" > ${OUTFILE}
+echo "ID    LABELS \n" > ${OUTFILE}
 
 echo "Pulling data from project issues... "
 
 # Loop throuh found issues.
 for ISSUE_ID in $ISSUE_ID_LIST
 do
-    # Get project title.
-    TITLE=$(gh issue view "${ISSUE_ID}" | grep 'title:' | cut -d':' -f2)
-
     # Get project labels.
     LABELS_LIST=$(gh issue view "${ISSUE_ID}" | grep 'labels:' | cut -d':' -f2)
 
@@ -70,7 +67,7 @@ do
     if [[ ${LABELS_LIST} == *project* ]] && [[ ${LABELS_LIST} == *status:web_ready* || ${LABELS_LIST} == *status:published* ]]
     then
         # Save ID, title and labels to output file.
-        echo "${ISSUE_ID##*( )}    ${TITLE##*( )}    ${LABELS_LIST##*( )}\n" >> ${OUTFILE}
+        echo "${ISSUE_ID##*( )}    ${LABELS_LIST##*( )}\n" >> ${OUTFILE}
     fi
 done
 

--- a/tools/pull_issues.sh
+++ b/tools/pull_issues.sh
@@ -53,7 +53,7 @@ fi
 ISSUE_ID_LIST=$(gh issue list -L 1000 -l "${EVENT}"| awk '{print $1}')
 
 # Create output file and add header.
-echo "ID \t TITLE \t LABELS \n" > ${OUTFILE}
+echo "ID    TITLE    LABELS \n" > ${OUTFILE}
 
 echo "Pulling data from project issues... "
 
@@ -70,7 +70,7 @@ do
     if [[ ${LABELS_LIST} == *project* ]] && [[ ${LABELS_LIST} == *status:web_ready* || ${LABELS_LIST} == *status:published* ]]
     then
         # Save ID, title and labels to output file.
-        echo "${ISSUE_ID##*( )} \t ${TITLE##*( )} \t ${LABELS_LIST##*( )} \n" >> ${OUTFILE}
+        echo "${ISSUE_ID##*( )}    ${TITLE##*( )}    ${LABELS_LIST##*( )}\n" >> ${OUTFILE}
     fi
 done
 

--- a/tools/pull_issues.sh
+++ b/tools/pull_issues.sh
@@ -5,7 +5,7 @@ display_usage() {
     echo "Usage:"
     echo "\tsh pull_issues.sh OUTPUT EVENT (REPO)\n"
     echo "Arguments:\n"
-    echo "\tOUTPUT [required]: Path to store the output file. It can also be a filename.\n"
+    echo "\tOUTPUT [required]: Path to store the output file. It can also be a filename. It must have the '.tsv' extension.\n"
     echo "\tEVENT [required]: Label of the Brainhack Global event to pull project data from. It must start by 'bhg:'.\n"
     echo "\tREPO [optional]: Path to global 2020 repository. Usefule if you do not want to clone the repository again."
     echo "\tIf this argument is not given, the script will clone the repository and delete it once the script finishes.\n"

--- a/tools/pull_issues.sh
+++ b/tools/pull_issues.sh
@@ -1,13 +1,43 @@
 #!/bin/bash
 
+display_usage() {
+    echo "This script will save the ID, title and labels of the Brainhack Global projects for the given event.\n"
+    echo "Usage:"
+    echo "\tsh pull_issues.sh OUTPUT EVENT (REPO)\n"
+    echo "Arguments:\n"
+    echo "\tOUTPUT [required]: Path to store the output file. It can also be a filename.\n"
+    echo "\tEVENT [required]: Label of the Brainhack Global event to pull project data from. It must start by 'bhg:'.\n"
+    echo "\tREPO [optional]: Path to global 2020 repository. Usefule if you do not want to clone the repository again."
+    echo "\tIf this argument is not given, the script will clone the repository and delete it once the script finishes.\n"
+    echo "Help:\n"
+    echo "\tYou can display this help message using the '-h' and '--help' flags as in:\n"
+    echo "\t'pull_issues.sh -h' or 'pull_issues.sh --help'"
+} 
+
+# If no arguments are supplied, display usage.
+if [  $# -le 1 ]
+then
+    display_usage
+    exit 1
+fi
+
+# Check whether user supplied -h or --help . If yes, display usage.
+if [[ ( $* == "--help") ||  $* == "-h" ]]
+then
+    display_usage
+    exit 0
+fi
+
 # Filename of output file (it can include the path).
 OUTFILE=$1
+# Event label.
+EVENT=$2
 # Path to the repository. It can be empty
-REPOPATH=$2
+REPOPATH=$3
 
 # If REPOPATH is given then move into that directory and if it is not given then
 # clone Brainhack Global 2020 repository to get project info and move into directory.
-if [ $# -eq 2 ]
+if [ $# -eq 3 ]
 then
     echo "Moving into ${REPOPATH}"
     DIR_EXISTS=true
@@ -20,7 +50,7 @@ else
 fi
 
 # Get ID of projects on GitHub issues.
-ISSUE_ID_LIST=$(gh issue list -L 1000 -l "status:web_ready"| awk '{print $1}')
+ISSUE_ID_LIST=$(gh issue list -L 1000 -l "${EVENT}"| awk '{print $1}')
 
 # Create output file and add header.
 echo "ID \t TITLE \t LABELS \n" > ${OUTFILE}
@@ -36,8 +66,12 @@ do
     # Get project labels.
     LABELS_LIST=$(gh issue view "${ISSUE_ID}" | grep 'labels:' | cut -d':' -f2)
 
-    # Save ID, title and labels to output file.
-    echo "${ISSUE_ID##*( )} \t ${TITLE##*( )} \t ${LABELS_LIST##*( )} \n" >> ${OUTFILE}
+    # Only save the issue if the issue has the project and (web_ready or published) labels.
+    if [[ ${LABELS_LIST} == *project* ]] && [[ ${LABELS_LIST} == *status:web_ready* || ${LABELS_LIST} == *status:published* ]]
+    then
+        # Save ID, title and labels to output file.
+        echo "${ISSUE_ID##*( )} \t ${TITLE##*( )} \t ${LABELS_LIST##*( )} \n" >> ${OUTFILE}
+    fi
 done
 
 # Leave directory.


### PR DESCRIPTION
This PR adds:

- Help function to show the usage of the script when no arguments are passed or when the `-h` and the `--help` flags are passed.
- Given the gh CLI limitations, using multiple labels on one gh call behaves like an OR. What we really want is an AND, so the ID of all the `${EVENT}` issues are checked first and only those with the `status:web_ready`, `status:published` and `project` labels are saved into the output file.
- Tabs are no longer introduced with `\t` but rather with 4 spaces. The `\t` was introducing extra tabs which probably were the source of the issues we had with _pandas_. Now, only issue titles with quotations are a problem to generate the tsv, as they break into different rows. I haven't seen any other incorrect behavior with this approach.