### PR TITLE
BUG: Fix keeping the top match restricted results

### DIFF
--- a/brainmatch/brainmatch.py
+++ b/brainmatch/brainmatch.py
@@ -92,6 +92,8 @@ def compute_top_n(match_df, n):
             [x for y in zip(top_scores.index.tolist(), top_scores) for x in y]
         top_data = list([[data[0]], top_data])
         top_data = functools.reduce(operator.iconcat, top_data, [])
+        # Keep the top n results
+        top_data = top_data[:len(columns)]
         top_match.append(top_data)
 
     top_match_df = pd.DataFrame(top_match, columns=columns)


### PR DESCRIPTION
Fix keeping the top match restricted results: the dataframe column list
contained the names that were meant for the top-n results, but the row data
still contained the unrestricted results.