### PR TITLE
Fix/labels

### DIFF
--- a/brainmatch/brainmatch.py
+++ b/brainmatch/brainmatch.py
@@ -136,6 +136,9 @@ def compute_total_score(proj_features, contrib_data):
     contrib_git_skills = [int(s) for s in contrib_data[
         experience_git_skills_field].split(" ") if s.isdigit()][0]
 
+    # Take highest git level if more than one are given
+    proj_features[git_skills_label] = proj_features[git_skills_label][-1]
+
     proj_git_skills = int(
         proj_features[git_skills_label].split(underscore)[0]
         if proj_features[git_skills_label] else -1)

--- a/brainmatch/brainmatch.py
+++ b/brainmatch/brainmatch.py
@@ -136,8 +136,10 @@ def compute_total_score(proj_features, contrib_data):
     contrib_git_skills = [int(s) for s in contrib_data[
         experience_git_skills_field].split(" ") if s.isdigit()][0]
 
-    # Take highest git level if more than one are given
-    proj_features[git_skills_label] = proj_features[git_skills_label][-1]
+    # Sort the git skills labels in ascending order and take the highest skill
+    # level if more than one git skill label are given to a project.
+    proj_features[git_skills_label] = \
+        sorted(proj_features[git_skills_label])[-1]
 
     proj_git_skills = int(
         proj_features[git_skills_label].split(underscore)[0]

--- a/data/expected_match.csv
+++ b/data/expected_match.csv
@@ -1,7 +1,7 @@
-email_address_field,1,3
-participant1@bhg.org,0.67,0.21
-participant2@bhg.org,0.39,0.14
-participant3@bhg.org,0.39,0.32
-participant4@bhg.org,0.17,0.07
-participant5@bhg.org,0.06,0.11
-participant6@bhg.org,0.47,0.18
+email_address_field,1,3,4
+participant1@bhg.org,0.71,0.31,0.6
+participant2@bhg.org,0.48,0.25,0.4
+participant3@bhg.org,0.33,0.28,0.6
+participant4@bhg.org,0.29,0.19,0.6
+participant5@bhg.org,0.05,0.09,0.4
+participant6@bhg.org,0.55,0.16,0.2

--- a/data/expected_match_top.csv
+++ b/data/expected_match_top.csv
@@ -1,7 +1,7 @@
 email_address_field,id_top1,score_top1,id_top2,score_top2
-participant1@bhg.org,1,0.67,3,0.21
-participant2@bhg.org,1,0.39,3,0.14
-participant3@bhg.org,1,0.39,3,0.32
-participant4@bhg.org,1,0.17,3,0.07
-participant5@bhg.org,3,0.11,1,0.06
-participant6@bhg.org,1,0.47,3,0.18
+participant1@bhg.org,1,0.71,4,0.6
+participant2@bhg.org,1,0.48,4,0.4
+participant3@bhg.org,4,0.6,1,0.33
+participant4@bhg.org,4,0.6,1,0.29
+participant5@bhg.org,4,0.4,3,0.09
+participant6@bhg.org,1,0.55,4,0.2

--- a/data/projects.tsv
+++ b/data/projects.tsv
@@ -1,4 +1,5 @@
 ID    LABELS
-1    	programming:Python, tools:DIPY, tools:ANTs, modality:DWI, programming:Julia, programming:R, bhg:boston_usa_1
+1    	programming:Python, tools:DIPY, tools:ANTs, modality:DWI, programming:Julia, programming:R, git_skills:2_branches_PRs, bhg:boston_usa_1
 2    	programming:Bash, tools:FSL
-3    	modality:MEG, programming:Bash, programming:Matlab, tools:MNE, tools:SPM, tools:Nipype, tools:Freesurfer, bhg:boston_usa_1
+3    	modality:MEG, programming:Bash, programming:Matlab, tools:MNE, tools:SPM, tools:Nipype, tools:Freesurfer, git_skills:3_continuous_integration, bhg:boston_usa_1
+4    	modality:EEG, programming:C++, tools:MNE, git_skills:2_branches_PRs, git_skills:1_commit_push, bhg:boston_usa_1

--- a/tools/pull_issues.sh
+++ b/tools/pull_issues.sh
@@ -61,7 +61,8 @@ echo "Pulling data from project issues... "
 for ISSUE_ID in $ISSUE_ID_LIST
 do
     # Get project labels.
-    LABELS_LIST=$(gh issue view "${ISSUE_ID}" | grep 'labels:' | cut -d':' -f2)
+    LABELS_LIST=$(gh issue view "${ISSUE_ID}" | grep 'labels:')
+    LABELS_LIST=${LABELS_LIST#"labels:"}
 
     # Only save the issue if the issue has the project and (web_ready or published) labels.
     if [[ ${LABELS_LIST} == *project* ]] && [[ ${LABELS_LIST} == *status:web_ready* || ${LABELS_LIST} == *status:published* ]]


### PR DESCRIPTION
This PR addresses the following issues:

- There was a bug with `git_skills_label` that would break the code because the `.split( )` function cannot be used on a list, which `proj_features[git_skills_label]` was. I believe this could come from the fact that our participants answered to that particular question with more than one option.
- The `pull_issues.sh` script was failing because the labels were not correctly retrieved. I simplified the retrieval of labels and it works properly now.