### PR TITLE
DOC: Clarify the assumptions about `git_skills` labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ able to send participants an email with information about the projects that
 potentially fit them better within the context of the event.
 
 To gather these data we recommend using the [Brainhack Global Participant Registration Form](https://github.com/brainhackorg/bhg-event-materials)
-provided by the Brainhack Global Organization as a convenience participant 
+provided by the Brainhack Global Organization as a convenience participant
 registration form.
- 
+
 ## Context
 
 The tools assume that the projects submitted as issues to the [https://github.com/brainhackorg/global2020](https://github.com/brainhackorg/global2020)
@@ -36,7 +36,11 @@ needs to perfectly match the available labels in the project issues in the
 
 The scoring method does not currently take into account the required level of
 expertise for a project, nor is the participant's desired project type taken
-into account.
+into account. Similarly, the method assumes that, even if multiple  `git_skills`
+labels may be present for a project, the involved skills are incremental, and
+hence, only the most demanding skill (according to the fixed scale/label values)
+is taken into account to compute the contribution of such category to the score
+for a given participant.
 
 The scores are normalized to 1.
 


### PR DESCRIPTION
Clarify the assumptions about the contribution of a project's `git_skills`
labels to the computation of the scores.