### PR TITLE
STYLE: Fix `E501` PEP8 warning

### DIFF
--- a/brainmatch/brainmatch.py
+++ b/brainmatch/brainmatch.py
@@ -110,7 +110,8 @@ def get_projects_features(project_data):
     # Get the values from the labels corresponding to each feature
     for key in project_features.keys():
         project_features[key] = \
-            [label.replace(key, "").strip() for label in labels if key in label]
+            [label.replace(key, "").strip()
+             for label in labels if key in label]
 
     return project_features
 


### PR DESCRIPTION
Fix `E501` PEP8 warning.

Fixes
```
E501 line too long (80 > 79 characters)
```

raised for example in:
https://github.com/jhlegarreta/brainmatch/runs/2701860121?check_suite_focus=true#step:7:24