### PR TITLE
ENH: Fix documentation interactive example test

### DIFF
--- a/brainmatch/brainmatch.py
+++ b/brainmatch/brainmatch.py
@@ -75,6 +75,7 @@ def _generate_top_match_column_names(n):
     --------
     >>> n = 2
     >>> columns = _generate_top_match_column_names(n)
+    >>> print(columns)
     ['id_top1', 'score_top1', 'id_top2', 'score_top2']
     """
 


### PR DESCRIPTION
Fix documentation interactive example test.

Fixes:
```
074     Examples
075     --------
076     >>> n = 2
077     >>> columns = _generate_top_match_column_names(n)
Expected:
    ['id_top1', 'score_top1', 'id_top2', 'score_top2']
Got nothing
```

raised for example in:
https://github.com/jhlegarreta/brainmatch/runs/2719834370?check_suite_focus=true#step:7:59