### PR TITLE
ENH: Test brainmatch score computing script

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -54,7 +54,7 @@ jobs:
         flake8 --version
         python -c 'import brainmatch'
         flake8 . --count --statistics
-        coverage run --source brainmatch -m pytest brainmatch -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
+        coverage run --source brainmatch -m pytest -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results
       uses: actions/upload-artifact@main

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -7,6 +7,10 @@ DATA_DIR = pjoin(dirname(__file__))
 
 TEST_FILES = {
     "expected_match": pjoin(DATA_DIR, "expected_match.csv"),
+    "expected_match_global": pjoin(DATA_DIR, "expected_match_global.csv"),
+    "expected_match_global_top": pjoin(
+        DATA_DIR, "expected_match_global_top.csv"),
+    "expected_match_top": pjoin(DATA_DIR, "expected_match_top.csv"),
     "fields": pjoin(DATA_DIR, "fields.json"),
     "participant_registration": pjoin(
         DATA_DIR, "participant_registration.csv"),

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 coverage
 numpy
 pytest
+pytest_console_scripts

--- a/scripts/tests/test_compute_brainmatch_scores.py
+++ b/scripts/tests/test_compute_brainmatch_scores.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import tempfile
+
+import pandas as pd
+
+from data import TEST_FILES
+
+tmp_dir = tempfile.TemporaryDirectory()
+
+
+def test_display_help(script_runner):
+
+    ret = script_runner.run("compute_brainmatch_scores.py",
+                            "--help")
+    assert ret.success
+
+
+def test_execution(script_runner):
+
+    os.chdir(os.path.expanduser(tmp_dir.name))
+
+    in_projects_fname = TEST_FILES["projects"]
+    in_contributors_fname = TEST_FILES["participant_registration"]
+    in_contributors_fields_fname = TEST_FILES["fields"]
+
+    out_match_file_rootname = "brainmatch_scores"
+    out_match_file_basename = out_match_file_rootname + ".csv"
+    out_match_fname = os.path.join(".", out_match_file_basename)
+
+    out_top_match_file_rootname = "brainmatch_scores_top"
+    out_top_match_file_basename = out_top_match_file_rootname + ".csv"
+    out_top_match_fname = os.path.join(".", out_top_match_file_basename)
+
+    # Test with site-specific BHG event projects
+    ret = script_runner.run(
+        "compute_brainmatch_scores.py",
+        "bhg:boston_usa_1",
+        in_projects_fname,
+        in_contributors_fname,
+        in_contributors_fields_fname,
+        out_match_fname)
+
+    assert ret.success
+
+    expected_val = pd.read_csv(TEST_FILES["expected_match"])
+    obtained_val = pd.read_csv(out_match_fname)
+
+    pd.testing.assert_frame_equal(obtained_val, expected_val)
+
+    # Test with the top rank results
+    ret = script_runner.run(
+        "compute_brainmatch_scores.py",
+        "bhg:boston_usa_1",
+        in_projects_fname,
+        in_contributors_fname,
+        in_contributors_fields_fname,
+        out_match_fname,
+        "--n", "2")
+
+    assert ret.success
+
+    expected_val = pd.read_csv(TEST_FILES["expected_match_top"])
+    obtained_val = pd.read_csv(out_top_match_fname)
+
+    pd.testing.assert_frame_equal(obtained_val, expected_val)
+
+    out_match_file_rootname = "brainmatch_scores"
+    out_match_file_basename = out_match_file_rootname + ".csv"
+    out_match_fname = os.path.join(".", out_match_file_basename)
+
+    # Test with global BHG event projects
+    ret = script_runner.run(
+        "compute_brainmatch_scores.py",
+        "bhg:global",
+        in_projects_fname,
+        in_contributors_fname,
+        in_contributors_fields_fname,
+        out_match_fname)
+
+    assert ret.success
+
+    expected_val = pd.read_csv(TEST_FILES["expected_match_global"])
+    obtained_val = pd.read_csv(out_match_fname)
+
+    pd.testing.assert_frame_equal(obtained_val, expected_val)
+
+    # Test with the top rank results
+    ret = script_runner.run(
+        "compute_brainmatch_scores.py",
+        "bhg:global",
+        in_projects_fname,
+        in_contributors_fname,
+        in_contributors_fields_fname,
+        out_match_fname,
+        "--n", "2")
+
+    assert ret.success
+
+    expected_val = pd.read_csv(TEST_FILES["expected_match_global_top"])
+    obtained_val = pd.read_csv(out_top_match_fname)
+
+    pd.testing.assert_frame_equal(obtained_val, expected_val)


### PR DESCRIPTION
Test brainmatch score computing script.

Allow the rest of the files in the `data` folder to be retrieved in tests.

Add the necessary `pytest_console_scripts` package to the dev requirements.