### PR TITLE
ENH: Install package in `GitHub` testing workflow

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -54,6 +54,7 @@ jobs:
         flake8 --version
         python -c 'import brainmatch'
         flake8 . --count --statistics
+        python setup.py develop
         coverage run --source brainmatch -m pytest -o junit_family=xunit2 -v --doctest-modules --junitxml=junit/test-results-${{ runner.os }}-${{ matrix.python-version }}.xml
 
     - name: Upload pytest test results


### PR DESCRIPTION
Install package in `GitHub` testing workflow.

Fixes:
```
>       raise FileNotFoundError('Cannot find ' + command)
E       FileNotFoundError: Cannot find compute_brainmatch_scores.py
```

raised for example in
https://github.com/brainhackorg/brainmatch/runs/2793995399?check_suite_focus=true#step:7:76

From https://pypi.org/project/pytest-console-scripts/,
`pytest-console-scripts` relies on the scripts being located in the path, hence
it can only run the console scripts from packages that have been installed.