### PR TITLE
STYLE: Prefer bare Python shebang

### DIFF
--- a/scripts/tests/test_compute_brainmatch_scores.py
+++ b/scripts/tests/test_compute_brainmatch_scores.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
Prefer using the bare (i.e. without Python 2 vs. Python 3 mayor version number)
shebang since the script is only expected to be run in an activated virtual
environment.

From PEP 394:
https://www.python.org/dev/peps/pep-0394/#for-python-script-publishers