### PR TITLE
ENH: Use latest `checkout` and `setup-python` action releases

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Use latest `checkout` and `setup-python` action releases.